### PR TITLE
Fix for failing installation of Agent when no sitelist available (unmanaged mode)

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -15,7 +15,7 @@ end
 windows_package node['mcafee']['agent']['package_name'] do
   source node['mcafee']['agent']['url']
   checksum node['mcafee']['agent']['checksum']
-  options "/Install=Agent /Silent"
+  options "/Install=Updater /Silent"
   installer_type :custom
   action :install
 end


### PR DESCRIPTION
When installing the McAfee agent without ePO (yet) you have to install it in unmanaged mode. If you run FramePkg.exe /? you will see that the option to use is "/Install=Updater" and not "/Install=Agent".